### PR TITLE
Feature: JS 함수와 WASM 성능 측정 함수 구현

### DIFF
--- a/src/logic/performance-comparison/measurementExecutor.js
+++ b/src/logic/performance-comparison/measurementExecutor.js
@@ -26,12 +26,12 @@ export default async function executeMeasurementInVm({
       return "getPerformanceResult({ jsFn, wasmFn, args })";
     });
 
-  const code = `const performanceResults = (async () => {
+  const scriptSource = `const performanceResults = (async () => {
     return await Promise.allSettled([${funcExecutionList.join(",")}]);
   })();`;
 
-  const script = new vm.Script(code);
-  const context = {
+  const scriptCode = new vm.Script(scriptSource);
+  const sandboxEnv = {
     getPerformanceResult,
     measurePerformanceByFunc,
     args,
@@ -39,8 +39,8 @@ export default async function executeMeasurementInVm({
     jsFn: jsFunc,
   };
 
-  vm.createContext(context);
-  script.runInContext(context);
+  const executionContext = vm.createContext(sandboxEnv);
+  scriptCode.runInContext(executionContext);
 
   return await context.performanceResults;
 }

--- a/src/logic/performance-comparison/measurementExecutor.js
+++ b/src/logic/performance-comparison/measurementExecutor.js
@@ -1,0 +1,46 @@
+import vm from "vm";
+
+import { createWasmInstance } from "@utils/webAssemblyUtils";
+import { generateJsCode } from "@utils/vmUtils";
+import parseJscodeToAST from "@utils/jsToAstParser";
+
+import {
+  getPerformanceResult,
+  measurePerformanceByFunc,
+} from "@logic/performance-comparison/performanceAnalysis";
+
+import getIdentifierNameListByFunc from "@logic/ast-analysis/getIdentifierNameList";
+
+export default function executeMeasurementInVm({
+  javascriptCode,
+  assemblyScriptCode,
+  args,
+  repeatCount,
+}) {
+  const ELEMENT_TO_FILL = 0;
+
+  const wasmInstance = createWasmInstance(assemblyScriptCode);
+  const jsFunc = generateJsCode(javascriptCode);
+  const executeFuncName = javascriptCode.match(/function (\w+)/)[1];
+
+  const execStatementList = new Array(repeatCount)
+    .fill(ELEMENT_TO_FILL)
+    .map((_) => {
+      return "getPerformanceResult({ jsFn, wasmFn, args })";
+    });
+
+  const code = `(async () => {
+    return await Promise.allSettled([${execStatementList.join(",")}]);
+  })();`;
+
+  const script = new vm.Script(code);
+  const context = {
+    getPerformanceResult,
+    measurePerformanceByFunc,
+    args,
+    wasmFn: wasmInstance[executeFuncName],
+    jsFn: jsFunc,
+  };
+  vm.createContext(context);
+  script.runInContext(context);
+}

--- a/src/logic/performance-comparison/performanceAnalysis.js
+++ b/src/logic/performance-comparison/performanceAnalysis.js
@@ -1,0 +1,25 @@
+export function measurePerformanceByFunc(targetFunc, args) {
+  const startTime = performance.now();
+  const startCpu = process.cpuUsage();
+
+  targetFunc(...args);
+
+  const endCpu = process.cpuUsage(startCpu);
+  const endTime = performance.now();
+
+  return {
+    cpuUsage: endCpu,
+    runTime: endTime - startTime,
+  };
+}
+
+export async function getPerformanceResult({ jsFn, wasmFn, args }) {
+  const resultList = await Promise.allSettled([
+    measurePerformance(jsFn, args),
+    measurePerformance(wasmFn, args),
+  ]);
+
+  const [jsPerformance, wasmPerformance] = resultList;
+
+  return { jsPerformance, wasmPerformance };
+}

--- a/src/utils/codeGenerator.js
+++ b/src/utils/codeGenerator.js
@@ -1,0 +1,9 @@
+import vm from "vm";
+
+export function generateJsCode(stringJsCode) {
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(stringJsCode, context);
+
+  return context;
+}

--- a/src/utils/codeGenerator.test.js
+++ b/src/utils/codeGenerator.test.js
@@ -1,0 +1,18 @@
+import { generateJsCode } from "./codeGenerator";
+
+describe("Generate JavaScript Code", () => {
+  const targetStringCode = `
+    function fibonacci(n) {
+      if (n <= 1) return n;
+      return fibonacci(n - 1) + fibonacci(n - 2);
+    }
+  `;
+
+  it("문자열 형식의 JS코드를 기반으로 함수 생성하며 실제 함수처럼 동작해야합니다.", () => {
+    const { fibonacci } = generateJsCode(targetStringCode);
+
+    expect(fibonacci(1)).toBe(1);
+    expect(fibonacci(5)).toBe(5);
+    expect(fibonacci(10)).toBe(55);
+  });
+});

--- a/src/utils/webAssemblyUtils.js
+++ b/src/utils/webAssemblyUtils.js
@@ -1,0 +1,10 @@
+import asc from "assemblyscript/dist/asc.js";
+
+export async function createWasmInstance(stringCode) {
+  const { binary: wasmBuffer } = await asc.compileString(stringCode, {
+    optimize: true,
+  });
+  const wasmModule = await WebAssembly.instantiate(wasmBuffer);
+
+  return { ...wasmModule.instance.exports };
+}


### PR DESCRIPTION
 ## 작업 진행 내용
문자열 형태의 JavaScript 코드와 AssemblyScript를 각각 실행할 수 있는 형태의 함수와 인스턴스로 생성하여 실행한 후 성능 측정 결과를 반환하는 함수를 구현하는 작업을 진행하였습니다.

> 성능 비교 기준은 연산 과정에서 사용한 CPU 사용량과 연산 처리 속도 입니다.

### 💻 TO DO

- [x] 문자열 형태의 JavaScript 코드를 실행할 수 있는 형태의 함수로 생성해야합니다.
- [x] 문자열 형태의 AssemblyScript를 컴파일하여 인스턴스를 생성해야합니다
- [x] 함수와 인스턴스를 실행하여 각 성능을 측정하고 측정 결과를 수집하여 반환해야합니다.

## 📢 리뷰어 안내 사항

- 서버의 안정성과 JS 함수와 WASM 모두 동일한 환경에서 성능을 측정하기 위해 VM 환경에서 성능을 측정하도록 작업을 진행하였습니다.
- Jest의 `Cannot find module` 에러가 발생하여 AssemblyScript 컴파일 API 를 사용하여 인스턴스를 생성하는 로직에 대한 테스트는 진행하지 못 하였습니다.
![스크린샷 2024-08-23 17 37 25](https://github.com/user-attachments/assets/97e53fb6-8450-47f3-902b-23c208fcb827)

### ✅ PR 작성 전 체크 리스트

> **체크 항목을 모두 완료 후 PR를 작성합니다.**

- [x] PR 작성 내용은 300-500자 내외로 작성하도록하며 최대 1000자를 넘지 않도록 합니다.
- [x] 충돌 `conflict`이 발생되는 경우 충돌을 해결한 뒤 PR을 작성합니다.
- [x] 가장 최신 브랜치를 Pull 했습니다.
- [x] base 브랜치명을 확인했습니다.
- [x] 코드 컨벤션을 모두 확인했습니다.
- [x] 브랜치 명을 확인했습니다.
- [x] 작업 중 `dependency` 변경사항과 같은 작업 환경에 설정 변경되는 경우 주의 사항을 작성합니다.
