### PR TITLE
Fix: 성능 측정 방식 및 로직 수정

### DIFF
--- a/src/components/guide/Guide.jsx
+++ b/src/components/guide/Guide.jsx
@@ -7,7 +7,7 @@ import {
   GUIDE_MOCK_DATA,
   GUIDE_DIFF_EDITOR_JS_VLAUE,
   GUIDE_DIFF_EDITOR_TRANSPILED_AS_VALUE,
-} from "@/constants/constant";
+} from "@constants/constant";
 
 export default function Guide() {
   return (

--- a/src/components/visualization/PerformanceComparisonChart.jsx
+++ b/src/components/visualization/PerformanceComparisonChart.jsx
@@ -10,10 +10,10 @@ export default function PerformanceComparisonChart({ data }) {
   const chartInstanceRef = useRef(null);
 
   useEffect(() => {
-    const labels = data.operationTimesPerSecond.map((item) =>
+    const labels = data.measurementResults.map((item) =>
       item.type.toUpperCase(),
     );
-    const operationTimes = data.operationTimesPerSecond.map(
+    const operationTimes = data.measurementResults.map(
       (item) => item.operationTimes,
     );
     const purpleColor = "rgba(83, 91, 242, 1)";

--- a/src/components/visualization/SpeedReport.jsx
+++ b/src/components/visualization/SpeedReport.jsx
@@ -1,13 +1,14 @@
 import Image from "next/image";
+import { MODULE_TYPE_TEXT } from "@constants/constant";
 
 export default function SpeedReport({ data }) {
-  const { operationTimesPerSecond } = data;
-  const wasmOperationTimes = operationTimesPerSecond.find(
-    (item) => item.type === "wasm",
+  const { measurementResults } = data;
+  const wasmOperationTimes = measurementResults.find(
+    (item) => item.type === MODULE_TYPE_TEXT.WEB_ASSEMBLY,
   ).operationTimes;
 
-  const jsOperationTimes = operationTimesPerSecond.find(
-    (item) => item.type === "js",
+  const jsOperationTimes = measurementResults.find(
+    (item) => item.type === MODULE_TYPE_TEXT.JAVASCRIPT,
   ).operationTimes;
 
   const speedDifference = (wasmOperationTimes / jsOperationTimes).toFixed(2);

--- a/src/constants/constant.js
+++ b/src/constants/constant.js
@@ -4,7 +4,7 @@ export const CODE_EDITOR_DEFAULT_VALUE = `
   }
 `;
 
-export const GUIDE_DIFF_EDITOR_JS_VLAUE = `
+export const GUIDE_DIFF_EDITOR_JS_VALUE = `
   function add(a, b) {
     return a + b;
   }`;
@@ -18,15 +18,20 @@ export const GUIDE_MOCK_DATA = {
   jsCode: "function yourFunction(a, b) { return a + b; }",
   transpiledAsCode:
     "function yourFunction(a: number, b: number): number { return a + b; }",
-  operationTimesPerSecond: [
+  measurementResults: [
     {
-      type: "js",
+      type: "JS",
       operationTimes: 142782,
     },
     {
-      type: "wasm",
+      type: "WASM",
       operationTimes: 582742,
     },
   ],
   performanceReportId: "guide-sample",
+};
+
+export const MODULE_TYPE_TEXT = {
+  JAVASCRIPT: "JS",
+  WEB_ASSEMBLY: "WASM",
 };

--- a/src/logic/performance-comparison/measurementExecutor.js
+++ b/src/logic/performance-comparison/measurementExecutor.js
@@ -18,7 +18,7 @@ export default async function executeMeasurementInVm({
   const jsFunc = generateJsCode(javascriptCode, extractedJsFuncName);
 
   const scriptSource = `
-    var operationTimesPerSecond = (async () => {
+    var measurementResults = (async () => {
       return await getPerformanceResultsByFunc({wasmFn, jsFn, args});
     })();
   `;
@@ -35,9 +35,9 @@ export default async function executeMeasurementInVm({
   let executionContext = vm.createContext(sandboxEnv);
   scriptCode.runInContext(executionContext);
 
-  const { operationTimesPerSecond } = executionContext;
+  const { measurementResults } = executionContext;
 
   executionContext = null;
 
-  return await operationTimesPerSecond;
+  return await measurementResults;
 }

--- a/src/logic/performance-comparison/performanceAnalysis.js
+++ b/src/logic/performance-comparison/performanceAnalysis.js
@@ -1,3 +1,5 @@
+import { MODULE_TYPE_TEXT } from "@constants/constant";
+
 export function measurePerformance(targetFunc, args, type, sec = 1) {
   const duration = sec * 1000;
   const startTimestamp = performance.now();
@@ -16,8 +18,8 @@ export function measurePerformance(targetFunc, args, type, sec = 1) {
 
 export async function getPerformanceResultsByFunc({ jsFn, wasmFn, args, sec }) {
   const performanceResult = await Promise.allSettled([
-    measurePerformance(jsFn, args, "JS", sec),
-    measurePerformance(wasmFn, args, "WASM", sec),
+    measurePerformance(jsFn, args, MODULE_TYPE_TEXT.JAVASCRIPT, sec),
+    measurePerformance(wasmFn, args, MODULE_TYPE_TEXT.WEB_ASSEMBLY, sec),
   ]);
 
   return performanceResult.map((result) => {

--- a/src/logic/performance-comparison/performanceAnalysis.js
+++ b/src/logic/performance-comparison/performanceAnalysis.js
@@ -1,49 +1,26 @@
-export function measurePerformanceByFunc(targetFunc, args, type) {
-  const startTime = performance.now();
-  const startCpu = process.cpuUsage();
+export function measurePerformance(targetFunc, args, type, sec = 1) {
+  const duration = sec * 1000;
+  const startTimestamp = performance.now();
+  let operationTimes = 0;
 
-  targetFunc(...args);
-
-  const endCpu = process.cpuUsage(startCpu);
-  const endTime = performance.now();
+  while (performance.now() - startTimestamp < duration) {
+    targetFunc(...args);
+    operationTimes++;
+  }
 
   return {
     type,
-    cpuUsage: endCpu.user,
-    executionTime: endTime - startTime,
+    operationTimes,
   };
 }
 
-export async function getPerformanceResult({ jsFn, wasmFn, args }) {
-  const [jsPerformanceResult, wasmPerformanceResult] = await Promise.allSettled(
-    [
-      measurePerformanceByFunc(jsFn, args, "JS"),
-      measurePerformanceByFunc(wasmFn, args, "WASM"),
-    ],
-  );
+export async function getPerformanceResultsByFunc({ jsFn, wasmFn, args, sec }) {
+  const performanceResult = await Promise.allSettled([
+    measurePerformance(jsFn, args, "JS", sec),
+    measurePerformance(wasmFn, args, "WASM", sec),
+  ]);
 
-  return {
-    jsPerformance: jsPerformanceResult.value ?? jsPerformanceResult.reason,
-    wasmPerformance:
-      wasmPerformanceResult.value ?? wasmPerformanceResult.reason,
-  };
-}
-
-export function calculateAverageExecutionTime(targetPerformanceResults) {
-  const filteredFulfilledResults = targetPerformanceResults.filter((result) => {
-    return (
-      result.hasOwnProperty("executionTime") &&
-      result.executionTime !== null &&
-      result.executionTime !== undefined
-    );
+  return performanceResult.map((result) => {
+    return result.value ?? result.reason;
   });
-
-  const totalExecutionTime = filteredFulfilledResults.reduce((acc, cur) => {
-    const currentExecutionTime = cur.executionTime;
-    acc += currentExecutionTime;
-
-    return acc;
-  }, 0);
-
-  return totalExecutionTime / filteredFulfilledResults.length;
 }

--- a/src/logic/performance-comparison/performanceAnalysis.test.js
+++ b/src/logic/performance-comparison/performanceAnalysis.test.js
@@ -1,83 +1,29 @@
-import {
-  calculateAverageExecutionTime,
-  measurePerformanceByFunc,
-} from "./performanceAnalysis";
+import { measurePerformance } from "./performanceAnalysis";
 
-describe("measurePerformanceByFunc", () => {
+describe("measurePerformance", () => {
   function add(a, b) {
     return a + b;
   }
 
-  function repeatConsoleLog(count) {
+  function repeat(count) {
     for (let i = 0; i < count; i++) {
-      console.log(`Count: ${count + i}`);
+      for (let j = 0; j < count / 2; j++) {}
     }
   }
 
   it("함수의 성능을 측정하며 결과를 반환해야합니다.", () => {
-    expect(measurePerformanceByFunc(add, [1, 2], "JS")).toEqual(
+    expect(measurePerformance(add, [1, 2], "JS")).toEqual(
       expect.objectContaining({
-        cpuUsage: expect.any(Number),
-        executionTime: expect.any(Number),
         type: expect.any(String),
+        operationTimes: expect.any(Number),
       }),
     );
 
-    expect(measurePerformanceByFunc(repeatConsoleLog, [3], "JS")).toEqual(
+    expect(measurePerformance(repeat, [10], "JS")).toEqual(
       expect.objectContaining({
-        cpuUsage: expect.any(Number),
-        executionTime: expect.any(Number),
         type: expect.any(String),
+        operationTimes: expect.any(Number),
       }),
-    );
-  });
-});
-
-describe("calculateAverageExecutionTime", () => {
-  const mockPerformanceResults = new Array(5).fill(0).map((_, index) => {
-    return {
-      cpuUsage: 0,
-      executionTime: 10,
-    };
-  });
-
-  const mockPerformanceRejectedResult = [
-    {
-      cpuUsage: 0,
-    },
-    {
-      cpuUsage: 0,
-      executionTime: null,
-    },
-    {
-      cpuUsage: 0,
-      executionTime: 10,
-    },
-    {
-      cpuUsage: 0,
-      executionTime: 10,
-    },
-    {
-      cpuUsage: 0,
-      executionTime: 10,
-    },
-  ];
-
-  it("성능 측정 결과를 순회하며 평균 실행 시간를 반환해야합니다.", () => {
-    expect(calculateAverageExecutionTime(mockPerformanceResults)).toEqual(
-      expect.any(Number),
-    );
-
-    expect(calculateAverageExecutionTime(mockPerformanceResults)).toBe(10);
-  });
-
-  it("측정에 실패한 결과가 존재할 경우 실한 결과를 제외한 평균 실행 시간를 반환해야합니다.", () => {
-    expect(
-      calculateAverageExecutionTime(mockPerformanceRejectedResult),
-    ).toEqual(expect.any(Number));
-
-    expect(calculateAverageExecutionTime(mockPerformanceRejectedResult)).toBe(
-      10,
     );
   });
 });


### PR DESCRIPTION
## 작업 진행 내용
기존 성능 측정 방식(CPU 사용량, 연산 처리 소요시간, JS 평균 연산 처리 소요시간, WASM 평균 연산 처리 소요시간)에서
`시간(초) 당 연산 실행 횟수`를 측정하는 방식으로 변경하는 작업을 진행하였습니다.
> Before
```
{
  "jsProcessingTimeMs": 0,
  "wasmProcessingTimeMs": 0,
  "jsMemoryTrackingResult": [{ memoryUsage: 0, cpuUsage: 0 }, ...],
  "wasmMemoryTrackingResult": [{ memoryUsage: 0, cpuUsage: 0 }, ...],
}
```

> After
```
[
  {
    type: "JS",
    operationTimes: 0,
  },{
    type: "WASM",
    operationTimes: 0,
  }
]
```

### 💻 TO DO

- [x]  성능 측정은 일정 시간 동안 JS 함수와 WASM 모듈이 실행된 횟수를 측정한다.
- [x]  VM 환경에서 성능을 측정한다.
- [x]  일정 시간은 인자로 전달 받으며 입력하지 않을 경우 1초를 기본값으로 진행하도록 한다.

### ⚠️ 주의 사항

- 성능 측정 방식 로직을 수정하며 불필요한 함수 및 함수명을 수정하였습니다
  - `measurePerformanceByFunc` -> `measurePerformance`
  - `getPerformanceResults` -> `getPerformanceResultsByFunc`
  - `calculateAverageExecutionTime` 삭제
- `executeMeasurementInVm`의 반환값이 변경되어, 해당 함수 호출 이후 작업에 수정 사항을 확인하시기 바랍니다.


### ✅ PR 작성 전 체크 리스트

> **체크 항목을 모두 완료 후 PR를 작성합니다.**

- [x] PR 작성 내용은 300-500자 내외로 작성하도록하며 최대 1000자를 넘지 않도록 합니다.
- [x] 충돌 `conflict`이 발생되는 경우 충돌을 해결한 뒤 PR을 작성합니다.
- [x] 가장 최신 브랜치를 Pull 했습니다.
- [x] base 브랜치명을 확인했습니다.
- [x] 코드 컨벤션을 모두 확인했습니다.
- [x] 브랜치 명을 확인했습니다.
- [x] 작업 중 `dependency` 변경사항과 같은 작업 환경에 설정 변경되는 경우 주의 사항을 작성합니다.
