### PR TITLE
Feat: 스켈레톤 로딩 UI & 에러 모달 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,8 +11,8 @@
   --color-darkgray: #505050;
   --color-notice-border: rgba(217, 119, 6, 0.8);
   --color-notice: rgba(217, 119, 6, 0.3);
-  --color-slower: rgba(57, 30, 26, 1);
-  --color-faster: rgba(35, 44, 11, 1);
+  --skeleton-base-color: #2c2c2c;
+  --skeleton-action-color: #1e1e1e;
 }
 
 body {
@@ -25,6 +25,38 @@ body {
 @layer utilities {
   .text-balance {
     text-wrap: balance;
+  }
+
+  .shimmer {
+    position: relative;
+    overflow: hidden;
+    background-color: rgb(39, 39, 39);
+  }
+
+  .shimmer::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 200%;
+    height: 100%;
+    background-image: linear-gradient(
+      90deg,
+      rgba(13, 13, 13, 0) 0%,
+      rgba(13, 13, 13, 0.2) 20%,
+      rgba(13, 13, 13, 0.8) 60%,
+      rgba(13, 13, 13, 0) 100%
+    );
+    animation: shimmer 2s infinite;
+  }
+
+  @keyframes shimmer {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(100%);
+    }
   }
 }
 

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -53,11 +53,15 @@ export default function Home() {
 
   async function handleModalSubmit(functionArguments) {
     const functionName = functionCode.match(/function (\w+)/)[1];
-    const functionCall = `${functionName}(${functionArguments.join(", ")})`;
     const normalizedFunctionCode = functionCode.replace(/\n/g, "");
-    const parsedFunctionArguments = JSON.stringify(
-      parseArguments(functionArguments),
-    );
+
+    const functionCall = functionArguments
+      ? `${functionName}(${functionArguments.join(", ")})`
+      : `${functionName}()`;
+
+    const parsedFunctionArguments = functionArguments
+      ? JSON.stringify(parseArguments(functionArguments))
+      : "[]";
 
     const requestBody = {
       functionCall,

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -16,11 +16,11 @@ export default function Home() {
   const [viewState, setViewState] = useState("guide");
   const [errorDetails, setErrorDetails] = useState({});
 
-  function handleOpenModal() {
+  function handleOpenArgsInputModal() {
     setIsModalOpen(true);
   }
 
-  function handleCloseModal() {
+  function handleCloseArgsInputModal() {
     setIsModalOpen(false);
   }
 
@@ -100,7 +100,7 @@ export default function Home() {
       setViewState("guide");
     }
 
-    handleCloseModal();
+    handleCloseArgsInputModal();
   }
 
   function renderContent() {
@@ -119,7 +119,7 @@ export default function Home() {
     <section className="flex flex-col lg:font-2 lg:flex-row justify-between items-center flex-grow gap-4 p-6">
       <ContentBox width="w-4/5 xl:w-[33%]">
         <CodeEditorWrapper
-          onExecute={handleOpenModal}
+          onExecute={handleOpenArgsInputModal}
           setFunctionCode={setFunctionCode}
         />
       </ContentBox>
@@ -130,7 +130,7 @@ export default function Home() {
       </ContentBox>
       <ArgsInputModal
         isOpen={isModalOpen}
-        onClose={handleCloseModal}
+        onClose={handleCloseArgsInputModal}
         functionCode={functionCode}
         onSubmit={handleModalSubmit}
       />

--- a/src/components/guide/Guide.jsx
+++ b/src/components/guide/Guide.jsx
@@ -22,7 +22,7 @@ export default function Guide() {
             <span className="text-2xl mr-2">&#9888;</span>
             Notice!
           </h2>
-          <ul className="mt-2 ml-6 list-disc">
+          <ul className="mt-2 ml-6 list-disc vw-3 md:text-xs lg:text-md xl:text-lg">
             <li>데이터 타입은 원시값(Number, String)만 지원합니다.</li>
             <li>입력한 함수와 동일한 갯수의 매개변수를 입력해주세요.</li>
             <li> 아래는 성능 비교 결과에 대한 예시입니다</li>

--- a/src/components/guide/Guide.jsx
+++ b/src/components/guide/Guide.jsx
@@ -5,7 +5,7 @@ import PerformanceComparisonChart from "@/components/visualization/PerformanceCo
 
 import {
   GUIDE_MOCK_DATA,
-  GUIDE_DIFF_EDITOR_JS_VLAUE,
+  GUIDE_DIFF_EDITOR_JS_VALUE,
   GUIDE_DIFF_EDITOR_TRANSPILED_AS_VALUE,
 } from "@constants/constant";
 
@@ -25,6 +25,7 @@ export default function Guide() {
           <ul className="mt-2 ml-6 list-disc">
             <li>데이터 타입은 원시값(Number, String)만 지원합니다.</li>
             <li>입력한 함수와 동일한 갯수의 매개변수를 입력해주세요.</li>
+            <li> 아래는 성능 비교 결과에 대한 예시입니다</li>
           </ul>
         </ContentBox>
         <ContentBox width="w-[48%]">
@@ -36,7 +37,7 @@ export default function Guide() {
       </div>
       <ContentBox custom="flex flex-col justify-around items-center gap-2">
         <DiffEditor
-          originalCode={GUIDE_DIFF_EDITOR_JS_VLAUE}
+          originalCode={GUIDE_DIFF_EDITOR_JS_VALUE}
           modifiedCode={GUIDE_DIFF_EDITOR_TRANSPILED_AS_VALUE}
         />
         <div className="flex flex-row justify-around w-full h-full pt-3">

--- a/src/components/loading/Loading.jsx
+++ b/src/components/loading/Loading.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import ContentBox from "@components/common/ContentBox";
-import SkeletonBox from "./SkeletonBox";
+import SkeletonBox from "@components/loading/SkeletonBox";
 
 export default function Loading() {
   return (

--- a/src/components/loading/Loading.jsx
+++ b/src/components/loading/Loading.jsx
@@ -1,7 +1,22 @@
+"use client";
+
+import ContentBox from "@components/common/ContentBox";
+import SkeletonBox from "./SkeletonBox";
+
 export default function Loading() {
   return (
-    <div>
-      <h1>로딩중</h1>
+    <div className="flex flex-col justify-between p-3 w-full h-full">
+      <ContentBox custom="flex flex-col justify-around items-center gap-2">
+        <SkeletonBox width="w-full" height="h-1/2" />
+        <div className="flex flex-row justify-around w-full h-1/2 pt-3 gap-4">
+          <ContentBox width="w-1/2" height="inherit">
+            <SkeletonBox width="w-full" height="h-full" />
+          </ContentBox>
+          <ContentBox width="w-2/5" height="inherit">
+            <SkeletonBox width="w-full" height="h-full" />
+          </ContentBox>
+        </div>
+      </ContentBox>
     </div>
   );
 }

--- a/src/components/loading/SkeletonBox.jsx
+++ b/src/components/loading/SkeletonBox.jsx
@@ -1,0 +1,5 @@
+export default function SkeletonBox({ width, height }) {
+  return (
+    <div className={`bg-black ${width} ${height} shimmer rounded-md`}></div>
+  );
+}

--- a/src/components/modal/ArgsInputModal.jsx
+++ b/src/components/modal/ArgsInputModal.jsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import Modal from "@components/modal/Modal";
+import AddArgForm from "@components/argsInput/AddArgForm";
+import ArgsInputList from "@components/argsInput/ArgsInputList";
+import Button from "@components/button/Button";
+
+export default function ArgsInputModal({
+  isOpen,
+  onClose,
+  functionCode,
+  onSubmit,
+}) {
+  const [args, setArgs] = useState([]);
+
+  const handleAddArg = (arg) => {
+    if (arg.trim() !== "") {
+      setArgs([...args, arg]);
+    }
+  };
+
+  const handleFormSubmit = (e) => {
+    e.preventDefault();
+    onSubmit(args);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="테스트 케이스 입력">
+      <form
+        onSubmit={handleFormSubmit}
+        className="flex flex-col justify-between h-full"
+      >
+        <AddArgForm onAddArg={handleAddArg} />
+        <ArgsInputList args={args} setArgs={setArgs} />
+        <div className="flex justify-end">
+          <Button
+            text="실행"
+            className="btn-purple-light px-4 py-2 rounded"
+            type="submit"
+          />
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/components/modal/ErrorModal.jsx
+++ b/src/components/modal/ErrorModal.jsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Modal from "@components/modal/Modal";
+import Button from "@components/button/Button";
+
+const ErrorModal = ({ isOpen, onClose, errorMessage, statusCode }) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      width="w-1/3"
+      height="h-auto"
+      padding=""
+    >
+      <div className="flex flex-col items-center justify-center px-4 py-6">
+        <div className="w-12 h-12 bg-red-500 text-white flex items-center justify-center rounded-full">
+          <span className="text-2xl font-bold">!</span>
+        </div>
+
+        <h2 className="mt-4 text-xl font-bold text-center">{errorMessage}</h2>
+
+        <p className="mt-2 text-center">(status code: {statusCode})</p>
+      </div>
+
+      <div className="w-full">
+        <Button
+          text="확인"
+          className="bg-red-500 w-full text-white py-3 rounded-b-md hover:bg-red-600 transition-colors"
+          onClick={onClose}
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default ErrorModal;

--- a/src/components/modal/ErrorModal.jsx
+++ b/src/components/modal/ErrorModal.jsx
@@ -16,10 +16,9 @@ const ErrorModal = ({ isOpen, onClose, errorMessage, statusCode }) => {
         <div className="w-12 h-12 bg-red-500 text-white flex items-center justify-center rounded-full">
           <span className="text-2xl font-bold">!</span>
         </div>
-
-        <h2 className="mt-4 text-xl font-bold text-center">{errorMessage}</h2>
-
-        <p className="mt-2 text-center">(status code: {statusCode})</p>
+        <h2 className="mt-4 text-xl py-8 font-bold text-center">
+          {errorMessage}
+        </h2>
       </div>
 
       <div className="w-full">

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -1,25 +1,16 @@
 "use client";
 
-import { useState } from "react";
 import Button from "@components/button/Button";
-import ArgsInputList from "@components/argsInput/ArgsInputList";
-import AddArgForm from "@components/argsInput/AddArgForm";
 
-const Modal = ({ isOpen, onClose, functionCode, onSubmit }) => {
-  const [args, setArgs] = useState([]);
-
-  const handleAddArg = (arg) => {
-    if (arg.trim() !== "") {
-      setArgs([...args, arg]);
-    }
-  };
-
-  const handleFormSubmit = (e) => {
-    e.preventDefault();
-    onSubmit(args);
-    onClose();
-  };
-
+export default function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  width = "w-1/2",
+  height = "h-1/2",
+  padding = "p-10",
+}) {
   if (!isOpen) return null;
 
   return (
@@ -28,7 +19,7 @@ const Modal = ({ isOpen, onClose, functionCode, onSubmit }) => {
       onClick={onClose}
     >
       <div
-        className="bg-[var(--modal-background-color)] flex flex-col justify-between w-3/6 h-3/6 p-10 border-indigo-500 rounded-lg relative"
+        className={`bg-[var(--modal-background-color)] flex flex-col justify-between ${width} ${height} ${padding} border-indigo-500 rounded-lg relative`}
         onClick={(e) => e.stopPropagation()}
       >
         <Button
@@ -36,24 +27,9 @@ const Modal = ({ isOpen, onClose, functionCode, onSubmit }) => {
           className="absolute top-2 right-2 text-white bg-transparent"
           onClick={onClose}
         />
-        <h1>테스트 케이스 입력</h1>
-        <form
-          onSubmit={handleFormSubmit}
-          className="flex flex-col justify-between h-full"
-        >
-          <AddArgForm onAddArg={handleAddArg} />
-          <ArgsInputList args={args} setArgs={setArgs} />
-          <div className="flex justify-end">
-            <Button
-              text="실행"
-              className="btn-purple-light px-4 py-2 rounded"
-              type="submit"
-            />
-          </div>
-        </form>
+        {title && <h1>{title}</h1>}
+        <div className="flex flex-col justify-between h-full">{children}</div>
       </div>
     </div>
   );
-};
-
-export default Modal;
+}

--- a/src/constants/apiErrorType.js
+++ b/src/constants/apiErrorType.js
@@ -5,7 +5,7 @@ export const ERROR_CASE = {
   },
   EXECUTION_FAULT: {
     message: "Javascript 함수 실행 실패",
-    statusCode: 200,
+    statusCode: 400,
   },
   AST_PARSING_ERROR: {
     message: "AST 파싱 에러",
@@ -17,6 +17,6 @@ export const ERROR_CASE = {
   },
   TYPE_INFERENCE_ERROR: {
     message: "객체와 배열타입은 지원되지 않습니다.",
-    statusCode: 200,
+    statusCode: 400,
   },
 };


### PR DESCRIPTION
## 작업 화면
| **[api 요청 성공]** |
|-----------|
![로딩UI-성공](https://github.com/user-attachments/assets/f3a85e07-2055-41f0-b60d-da1ae365f06e)| 

| **[api 요청 실패(에러 모달로 에러 메시지 제공)]** |
|-----------|
![로딩UI-실패-에러모달](https://github.com/user-attachments/assets/1f9b63c3-7f39-4544-891a-a92b78acd558)


## 작업 진행 내용
사용자가 JavaScript코드와 매개 변수를 입력한 후 성능 비교를 기다릴 때 제공되는 화면입니다.
api요청 성공 시 결과 화면으로 이동하고, 실패 시 에러 모달을 통해 에러 메시지를 제공합니다.

### 💻 TO DO

**[로딩 UI]**
- [x] 사용자가 JavaScript코드와 매개변수 입력을 서버로 전송한 후, 서버에서 응답이 올때까지 로딩 화면을 제공해야 한다.
- [x] 로딩 화면은 스켈레톤 애니메이션을 활용하여 구현한다.
- [x] 스켈레톤의 배치는 **결과 화면**과 동일한 구조로 구성되어야 한다.
- [x] `response.ok`가 포함된 응답을 받으면 성능 비교 결과 화면을 제공해야 한다.
- [x] `response.ok`가 포함되지 않은 응답을 받으면 에러 모달을 통해 에러 메시지를 제공할 수 있어야 한다.

**[에러 모달]**
- [x]  최상단에 경고 아이콘이 표시되어야 한다.
- [x]  `statusCode`에 따라 알맞은 메시지가 출력되어야 한다.
    - [x]  `statusCode`가 400일 때 "Bad Request"가 출력되어야 한다.
    - [x]  `statusCode`가 200일 때 "OK"가 출력되어야 한다.
    - [x]  `statusCode`가 500일 때 "Internal Server Error"가 출력되어야 한다.
- [x]  최하단에 에러 모달을 종료할 수 있는 버튼이 있어야 한다.
    - [x]  버튼은 상단의 메시지와는 약간의 간격이 있어야 한다.
    - [x]  모달 하단에 고정되어야 하고 모달 아래의 일정 영역을 여백 없이 차지하도록 해야 한다.
- [x]  모달의 닫힘 기능을 구현해야 한다.
    - [x]  모달 바깥 영역을 클릭하였을 때 닫혀야 한다.
    - [x]  모달 하단의 버튼을 클릭하였을 때 닫혀야 한다.
    - [x]  우상단의 “x” 버튼을 클릭하였을 때 닫혀야 한다.

### ✅ PR 작성 전 체크 리스트

> **체크 항목을 모두 완료 후 PR를 작성합니다.**

- [x] PR 작성 내용은 300-500자 내외로 작성하도록하며 최대 1000자를 넘지 않도록 합니다.
- [x] 충돌 `conflict`이 발생되는 경우 충돌을 해결한 뒤 PR을 작성합니다.
- [x] 가장 최신 브랜치를 Pull 했습니다.
- [x] base 브랜치명을 확인했습니다.
- [x] 코드 컨벤션을 모두 확인했습니다.
- [x] 브랜치 명을 확인했습니다.
- [x] 작업 중 `dependency` 변경사항과 같은 작업 환경에 설정 변경되는 경우 주의 사항을 작성합니다.
