### PR TITLE
Feature: 성능 비교 결과 상세정보를 보여주는 화면 구현

### DIFF
--- a/spec/server.spec.js
+++ b/spec/server.spec.js
@@ -29,7 +29,7 @@ describe("/api/performance-comparison", () => {
     method: "POST",
   });
 
-  it("매개변수가 객체 또는 배열인 경우 타입 추론 에러와 상태코드 200을 반환해야 한다.", async () => {
+  it("매개변수가 객체 또는 배열인 경우 타입 추론 에러와 상태코드 400을 반환해야 한다.", async () => {
     req.json = async () => ({
       functionCode: "function userCode(a) { return a }",
       functionArguments: "[[1, 2, 3]]",
@@ -39,11 +39,11 @@ describe("/api/performance-comparison", () => {
 
     const response = await POST(req);
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(400);
     expect(await response.json()).toHaveProperty("errorStackMessage");
   });
 
-  it("함수 로직 내부에 객체 또는 배열이 존재하는 경우 타입 추론 에러와 상태코드 200을 반환해야 한다.", async () => {
+  it("함수 로직 내부에 객체 또는 배열이 존재하는 경우 타입 추론 에러와 상태코드 400을 반환해야 한다.", async () => {
     req.json = async () => ({
       functionCode: `
         function userCode(a, b) {
@@ -58,7 +58,7 @@ describe("/api/performance-comparison", () => {
 
     const response = await POST(req);
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(400);
     expect(await response.json()).toHaveProperty("errorStackMessage");
   });
 });

--- a/src/app/api/performance-comparison/route.js
+++ b/src/app/api/performance-comparison/route.js
@@ -22,10 +22,14 @@ export async function POST(request) {
     const { functionCode, functionCall, functionArguments, functionName } =
       await request.json();
     const parsedFunctionArguments = JSON.parse(functionArguments);
+    const normalizedFunctionCode = functionCode.replace(/\n/g, "");
 
-    const userCodeResult = await executeUserCode(functionCode, functionCall);
+    const userCodeResult = await executeUserCode(
+      normalizedFunctionCode,
+      functionCall,
+    );
 
-    const jsAst = parseJscodeToAST(functionCode);
+    const jsAst = parseJscodeToAST(normalizedFunctionCode);
 
     validateArgsLength(jsAst, parsedFunctionArguments);
 
@@ -34,7 +38,11 @@ export async function POST(request) {
       parsedFunctionArguments,
       userCodeResult,
     );
-    const { code: asCode } = generate.default(asAst, {}, functionCode);
+    const { code: asCode } = generate.default(
+      asAst,
+      {},
+      normalizedFunctionCode,
+    );
 
     const asFilePath = await moduleBuild.createAsModule(
       asCode,
@@ -51,7 +59,7 @@ export async function POST(request) {
 
     const measurementResults = await executeMeasurementInVm({
       wasmBuffer,
-      javascriptCode: functionCode,
+      javascriptCode: normalizedFunctionCode,
       extractedJsFuncName: functionName,
       args: parsedFunctionArguments,
     });

--- a/src/app/measurement-result/[id]/page.jsx
+++ b/src/app/measurement-result/[id]/page.jsx
@@ -1,0 +1,54 @@
+import dynamic from "next/dynamic";
+
+import ReportSpeedBox from "@components/report/ReportSpeedBox";
+import ReportChartBox from "@components/report/ReportChartBox";
+import SpeedReport from "@components/visualization/SpeedReport";
+import { findPerformanceReportById } from "@logic/db-query/performanceResultQuery";
+
+const DynamicPerformanceComparisonChart = dynamic(
+  () => import("@components/visualization/PerformanceComparisonChart"),
+  { ssr: false },
+);
+const DynamicDiffEditor = dynamic(
+  () => import("@components/editor/ReportDiffEditor"),
+  { ssr: false },
+);
+
+export default async function ResultPage({ params }) {
+  const { id } = params;
+
+  const report = await findPerformanceReportById(id);
+
+  return (
+    <section className="flex flex-col justify-center items-center p-6 w-full h-full">
+      <div className="flex flex-col h-full min-h-[50vh]">
+        <div className="h-1/2 pb-3">
+          <DynamicDiffEditor
+            height="100%"
+            theme="vs-dark"
+            language="javascript"
+            originalCode={report.jsCode}
+            modifiedCode={report.transpiledAsCode}
+            options={{
+              renderSideBySide: true,
+              readOnly: true,
+            }}
+          />
+        </div>
+        <div className="h-1/2 flex justify-between">
+          <ReportChartBox>
+            <DynamicPerformanceComparisonChart data={report} />
+          </ReportChartBox>
+          <div
+            className="w-[35%]"
+            custum="flex flex-col justify-between ml-1.5"
+          >
+            <ReportSpeedBox>
+              <SpeedReport data={report} />
+            </ReportSpeedBox>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/measurement-result/[id]/page.jsx
+++ b/src/app/measurement-result/[id]/page.jsx
@@ -18,6 +18,7 @@ export default async function ResultPage({ params }) {
   const { id } = params;
 
   const report = await findPerformanceReportById(id);
+  const { jsCode, transpiledAsCode } = report;
 
   return (
     <section className="flex flex-col justify-center items-center p-6 w-full h-full">
@@ -27,8 +28,8 @@ export default async function ResultPage({ params }) {
             height="100%"
             theme="vs-dark"
             language="javascript"
-            originalCode={report.jsCode}
-            modifiedCode={report.transpiledAsCode}
+            originalCode={jsCode}
+            modifiedCode={transpiledAsCode}
             options={{
               renderSideBySide: true,
               readOnly: true,

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -54,8 +54,6 @@ export default function Home() {
 
   async function handleModalSubmit(functionArguments) {
     const functionName = functionCode.match(/function (\w+)/)[1];
-    const normalizedFunctionCode = functionCode.replace(/\n/g, "");
-
     const functionCall = functionArguments
       ? `${functionName}(${functionArguments.join(", ")})`
       : `${functionName}()`;
@@ -67,7 +65,7 @@ export default function Home() {
     const requestBody = {
       functionCall,
       functionName,
-      functionCode: normalizedFunctionCode,
+      functionCode,
       functionArguments: parsedFunctionArguments,
     };
 

--- a/src/components/editor/GuideDiffEditor.jsx
+++ b/src/components/editor/GuideDiffEditor.jsx
@@ -1,7 +1,9 @@
+"use client";
+
 import React from "react";
 import { DiffEditor } from "@monaco-editor/react";
 
-export default function MyDiffEditor({ originalCode, modifiedCode }) {
+export default function GuideDiffEditor({ originalCode, modifiedCode }) {
   return (
     <DiffEditor
       height="6.9rem"

--- a/src/components/editor/ReportDiffEditor.jsx
+++ b/src/components/editor/ReportDiffEditor.jsx
@@ -1,0 +1,20 @@
+"use client";
+
+import React from "react";
+import { DiffEditor } from "@monaco-editor/react";
+
+export default function ReportDiffEditor({ originalCode, modifiedCode }) {
+  return (
+    <DiffEditor
+      height="100%"
+      theme="vs-dark"
+      language="javascript"
+      original={originalCode}
+      modified={modifiedCode}
+      options={{
+        renderSideBySide: true,
+        readOnly: true,
+      }}
+    />
+  );
+}

--- a/src/components/guide/Guide.jsx
+++ b/src/components/guide/Guide.jsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 import folderIcon from "@public/folder_filled.svg";
 import ContentBox from "@components/common/ContentBox";
-import DiffEditor from "@components/editor/DiffEditor";
+import GuideDiffEditor from "@components/editor/GuideDiffEditor";
 import SpeedReport from "@components/visualization/SpeedReport";
 import PerformanceComparisonChart from "@components/visualization/PerformanceComparisonChart";
 
@@ -45,7 +45,7 @@ export default function Guide() {
         </ContentBox>
       </div>
       <ContentBox custom="flex flex-col justify-around items-center gap-2">
-        <DiffEditor
+        <GuideDiffEditor
           originalCode={GUIDE_DIFF_EDITOR_JS_VALUE}
           modifiedCode={GUIDE_DIFF_EDITOR_TRANSPILED_AS_VALUE}
         />

--- a/src/constants/constant.js
+++ b/src/constants/constant.js
@@ -1,18 +1,15 @@
-export const CODE_EDITOR_DEFAULT_VALUE = `
-  function yourFunction(a, b) {
-    // your code...
-  }
+export const CODE_EDITOR_DEFAULT_VALUE = `function yourFunction(a, b) {
+  // your code...
+}
 `;
 
-export const GUIDE_DIFF_EDITOR_JS_VALUE = `
-  function add(a, b) {
-    return a + b;
-  }`;
+export const GUIDE_DIFF_EDITOR_JS_VALUE = `function add(a, b) {
+  return a + b;
+}`;
 
-export const GUIDE_DIFF_EDITOR_TRANSPILED_AS_VALUE = `
-  function add(a: i32, b: i32): i32 {
-    return a + b;
-  }`;
+export const GUIDE_DIFF_EDITOR_TRANSPILED_AS_VALUE = `function add(a: i32, b: i32): i32 {
+  return a + b;
+}`;
 
 export const GUIDE_MOCK_DATA = {
   jsCode: "function yourFunction(a, b) { return a + b; }",

--- a/src/logic/ast-analysis/typeInference.js
+++ b/src/logic/ast-analysis/typeInference.js
@@ -35,7 +35,6 @@ export default function assignFunctionTypes(
         const { id, init } = path.node;
 
         if (t.isIdentifier(id)) {
-          t.isArrayExpression(init);
           const inferredType = inferType(init.value);
           if (inferredType) {
             id.typeAnnotation = t.tsTypeAnnotation(inferredType);


### PR DESCRIPTION
## 화면 구현
![화면 기록 2024-08-30 오전 12 01 17](https://github.com/user-attachments/assets/2bea66eb-c02c-4d05-b529-5968502ca9a3)

## 작업 진행 내용
“공유”버튼으로 복사한 url 접속 시, 해당 url의 성능 비교 결과 내용(사용자가 입력한 JavaScript함수, 변환된 AssemblyScript코드, 기존의 JavaSrcript코드 실행과 WASM 모듈 실행의 성능 비교 결과)을 보여주는 화면을 구현합니다.

### 💻 TO DO

- [x]  데이터베이스에서 응답받은 내용을 prop으로 전달 받아야 한다.
- [x]  사용자가 입력한 JavaScript 함수가 정해진 컴포넌트에 표시되어야 한다.
- [x]  변환된 AssemblyScript코드가 정해진 컴포넌트에 표시되어야 한다.
- [x]  JavaScript코드 실행과 WASM모듈 실행의 성능 비교 결과가 정해진 컴포넌트에 표시되어야 한다.

### ⚠️ 주의 사항
## 📢 리뷰어 안내 사항
### ✅ PR 작성 전 체크 리스트

> **체크 항목을 모두 완료 후 PR를 작성합니다.**

- [x] PR 작성 내용은 300-500자 내외로 작성하도록하며 최대 1000자를 넘지 않도록 합니다.
- [x] 충돌 `conflict`이 발생되는 경우 충돌을 해결한 뒤 PR을 작성합니다.
- [x] 가장 최신 브랜치를 Pull 했습니다.
- [x] base 브랜치명을 확인했습니다.
- [x] 코드 컨벤션을 모두 확인했습니다.
- [x] 브랜치 명을 확인했습니다.
- [x] 작업 중 `dependency` 변경사항과 같은 작업 환경에 설정 변경되는 경우 주의 사항을 작성합니다.
